### PR TITLE
Issue #43: Add logging

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -60,6 +60,7 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'log' => \App\Http\Middleware\Log::class,
     ];
 
     /**
@@ -76,6 +77,7 @@ class Kernel extends HttpKernel
         \Illuminate\Routing\Middleware\ThrottleRequests::class,
         \Illuminate\Session\Middleware\AuthenticateSession::class,
         \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        \App\Http\Middleware\Log::class,
         \Illuminate\Auth\Middleware\Authorize::class,
     ];
 }

--- a/app/Http/Middleware/Log.php
+++ b/app/Http/Middleware/Log.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Support\Facades\Log as SystemLog;
+use Illuminate\Support\Facades\Auth;
+use Closure;
+
+class Log
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (Auth::check() && $request->isMethod('post')){
+            SystemLog::debug("User #" . Auth::user()->id . " sent request: path="
+                . $request->path() . "&"
+                . http_build_query($request->input()));
+        }
+        return $next($request);
+    }
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -37,21 +37,46 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['daily'],
+            'channels' => ['daily_error', 'daily_warning', 'daily_info', 'daily_debug'],
             'ignore_exceptions' => false,
+        ],
+
+        'daily_error' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/laravel.ERROR.log'),
+            'level' => 'error',
+            'days' => 31,
+            'bubble' => false
+        ],
+
+        'daily_warning' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/laravel.WARNING.log'),
+            'level' => 'notice',
+            'days' => 31,
+            'bubble' => false
+        ],
+
+        'daily_info' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/laravel.INFO.log'),
+            'level' => 'info',
+            'days' => 14,
+            'bubble' => false
+        ],
+
+        'daily_debug' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/laravel.DEBUG.log'),
+            'level' => 'debug',
+            'days' => 14,
+            'bubble' => false
         ],
 
         'single' => [
             'driver' => 'single',
             'path' => storage_path('logs/laravel.log'),
             'level' => 'debug',
-        ],
-
-        'daily' => [
-            'driver' => 'daily',
-            'path' => storage_path('logs/laravel.log'),
-            'level' => 'debug',
-            'days' => 14,
         ],
 
         'slack' => [

--- a/config/logging.php
+++ b/config/logging.php
@@ -37,7 +37,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['daily_error', 'daily_warning', 'daily_info', 'daily_debug'],
+            'channels' => ['daily_error', 'daily_info', 'daily_debug'],
             'ignore_exceptions' => false,
         ],
 
@@ -46,15 +46,6 @@ return [
             'path' => storage_path('logs/laravel.ERROR.log'),
             'level' => 'error',
             'days' => 31,
-            'bubble' => false
-        ],
-
-        'daily_warning' => [
-            'driver' => 'daily',
-            'path' => storage_path('logs/laravel.WARNING.log'),
-            'level' => 'notice',
-            'days' => 31,
-            'bubble' => false
         ],
 
         'daily_info' => [
@@ -62,7 +53,6 @@ return [
             'path' => storage_path('logs/laravel.INFO.log'),
             'level' => 'info',
             'days' => 14,
-            'bubble' => false
         ],
 
         'daily_debug' => [
@@ -70,7 +60,6 @@ return [
             'path' => storage_path('logs/laravel.DEBUG.log'),
             'level' => 'debug',
             'days' => 14,
-            'bubble' => false
         ],
 
         'single' => [

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,7 @@ Route::get('/', function () {
 
 Auth::routes();
 
-Route::middleware(['auth'])->group(function () {
+Route::middleware(['auth', 'log'])->group(function () {
     Route::get('/home', 'HomeController@index')->name('home');
     Route::get('/print', 'PrintController@index')->name('print')->middleware('can:print.print');
     Route::post('/print/modify_balance', 'PrintController@modify_balance')->name('print.modify');


### PR DESCRIPTION
Added automatic logging for every authenticated `POST` request.
The log level here is `DEBUG`, which will be stored in the
`laravel.DEBUG.[date].log` file. Separated the most important logging
levels into separate files, namely `DEBUG, INFO, WARNING, ERROR`.
There are more levels in Laravel (see docs), notice and warning
are grouped under `WARNING`, error and everything above are grouped
under `ERROR`. The latter two files are stored for a month, while the
former two for two weeks.

Custom logging can be introduced when necessary using the
`Illuminate\Support\Facades\Log facade`, e.g.` Log::info("message")`.