### PR TITLE
Issue #48: Add dummy data to the database for testing

### DIFF
--- a/database/factories/PrintAccountFactory.php
+++ b/database/factories/PrintAccountFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\PrintAccount;
+use Faker\Generator as Faker;
+
+$factory->define(PrintAccount::class, function (Faker $faker) {
+    return [
+        'balance' => 0,
+        'free_pages' => 0,
+        'free_page_deadline' => null
+    ];
+});

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -21,6 +21,7 @@ class CreateUsersTable extends Migration
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->integer('permission')->default(0);
+            $table->boolean('verified')->default(false);
             $table->rememberToken();
             $table->timestamps();
         });

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $this->call(UsersTableSeeder::class);
     }
 }

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -12,7 +12,7 @@ class UsersTableSeeder extends Seeder
     public function run()
     {
         DB::table('users')->insert([
-            'name' => 'Soros Orsolya',
+            'name' => 'Hapák József',
             'email' => 'root@eotvos.elte.hu',
             'password' => bcrypt('asdasdasd'),
             'permission' => 1,

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class UsersTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('users')->insert([
+            'name' => 'Soros Orsolya',
+            'email' => 'root@eotvos.elte.hu',
+            'password' => bcrypt('asdasdasd'),
+            'permission' => 1,
+            'verified' => true
+        ]);
+        DB::table('print_accounts')->insert([
+            'user_id' => '1',
+            'balance' => 100,
+            'free_pages' => 10,
+            'free_page_deadline' => null
+        ]);
+        factory(App\User::class, 10)->create()->each(function ($user) {
+            $user->printAccount()->save(factory(App\PrintAccount::class)->make(['user_id' => $user->id])); 
+        });
+    }
+}


### PR DESCRIPTION
Added seeding with inserting 10 dummy users and a preset admin.
The login credentials for the admin is `'root@eotvos.elte.hu'` and `'asdasdasd'`.

To run the seeding with a refreshed migration give the command:
`php artisan migrate:refresh --seed`
Before that, you might have to give the command:
`composer dump-autoload`