### PR TITLE
Configure mail client and send mail on sign up

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -11,6 +11,7 @@ use App\User;
 use App\Workshop;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Validator;
 
 class RegisterController extends Controller
@@ -151,6 +152,11 @@ class RegisterController extends Controller
                 throw new AuthorizationException();
         }
         $user->internetAccess->setWifiUsername();
+
+        // Send confirmation mail.
+        if (config('mail.active')) {
+            Mail::to($user)->send(new \App\Mail\Confirmation($user->name));
+        }
 
         return $user;
     }

--- a/app/Mail/Confirmation.php
+++ b/app/Mail/Confirmation.php
@@ -3,7 +3,6 @@
 namespace App\Mail;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 

--- a/app/Mail/Confirmation.php
+++ b/app/Mail/Confirmation.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class Confirmation extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $recipent;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($recipent)
+    {
+        $this->recipent = $recipent;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->text('emails.register')
+                    ->subject(__('registration.confirmed_signup'));
+    }
+}

--- a/config/mail.php
+++ b/config/mail.php
@@ -2,6 +2,9 @@
 
 return [
 
+    // Set to true, if you wish to send mails on triggers.
+    'active' => env('MAIL_ACTIVE', false),
+
     /*
     |--------------------------------------------------------------------------
     | Mail Driver
@@ -16,7 +19,7 @@ return [
     |
     */
 
-    'driver' => env('MAIL_DRIVER', 'smtp'),
+    'driver' => 'smtp',
 
     /*
     |--------------------------------------------------------------------------
@@ -29,7 +32,7 @@ return [
     |
     */
 
-    'host' => env('MAIL_HOST', 'smtp.mailgun.org'),
+    'host' => env('MAIL_HOST', 'smtp.gmail.com'),
 
     /*
     |--------------------------------------------------------------------------
@@ -57,7 +60,13 @@ return [
 
     'from' => [
         'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
-        'name' => env('MAIL_FROM_NAME', 'Example'),
+        'name' => env('APP_NAME', 'Urán'),
+    ],
+
+
+    'reply_to' => [
+        'address' => env('MAIL_REPLYTO_ADDRESS', 'hello@example.com'),
+        'name' => env('APP_NAME', 'Urán'),
     ],
 
     /*
@@ -71,7 +80,7 @@ return [
     |
     */
 
-    'encryption' => env('MAIL_ENCRYPTION', 'tls'),
+    'encryption' => 'tls',
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/lang/en/registration.php
+++ b/resources/lang/en/registration.php
@@ -10,5 +10,6 @@ return [
     'forgotpwd'=> 'Forgot your password?',
     'collegist_to_tenant' => 'This page is for collegist members only (whether you are a resident or not). If you want to register as a tenant (guest), click here!',
     'tenant_to_collegist' => 'This page is for the tenants (guests) of the collegium. If you are a collegist member (whether you are a resident or not), click here!',
+    'confirmed_signup' => 'Sign-up successfull',
 
 ];

--- a/resources/lang/hu/registration.php
+++ b/resources/lang/hu/registration.php
@@ -10,5 +10,5 @@ return [
     'forgotpwd'=> 'Elfelejtetted a jelszót?',
     'collegist_to_tenant' => 'Ez az oldal a bejáró és bentlakó collegistáknak szól. Ha vendégként szeretnél regisztrálni, kattints ide!',
     'tenant_to_collegist' => 'Ez az oldal a Collegium vendégeinek szól. Ha Collegium tagja vagy (bentlakó vagy bejáró), akkor kattints ide!',
-
+    'confirmed_signup' => 'Sikeres regisztráció',
 ];

--- a/resources/views/emails/register.blade.php
+++ b/resources/views/emails/register.blade.php
@@ -1,0 +1,7 @@
+Kedves {{ $recipent }}!
+
+Köszönjük, hogy regisztráltál az {{ config('app.name') }} rendszerbe.
+Regisztrációdat egy renszergazda hamarosan kezelni fogja, addig is kérjük türelmed.
+
+Üdvözlettel,
+a rendszergazdák


### PR DESCRIPTION
Configured mail client. From now on, we can create Mailable objects that can be sent to users. The contents can be either html, markdown, or plain text.

I defined a new env variable, MAIL_ACTIVE, which determines if mails should be sent or not. If you set it to true, you also have to configure the mail client.

There are some tuning available, and now other issues became unblocked, I will administer this accordingly. Notable TODOs:
 - setting locales
 - turning on confirmation for mail (ie the given mail is valid)
 - turning on password reminders
