### PR TITLE
Track collegist status

### DIFF
--- a/app/Http/Controllers/SecretariatController.php
+++ b/app/Http/Controllers/SecretariatController.php
@@ -3,8 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Semester;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class SecretariatController extends Controller
 {

--- a/app/Http/Controllers/SecretariatController.php
+++ b/app/Http/Controllers/SecretariatController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Semester;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class SecretariatController extends Controller
+{
+    public function list()
+    {
+        return Semester::current()->activeUsers;
+    }
+}

--- a/app/Semester.php
+++ b/app/Semester.php
@@ -5,7 +5,6 @@ namespace App;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 
-
 /** A semester is identified by a year and by it's either autumn or spring.
  * ie. a spring semester starting in february 2020 will be (2019, 2) since we write 2019/20/2.
  * The autumn semester starting in september 2020 is (2020, 1) since we write 2020/21/1.
@@ -21,7 +20,7 @@ class Semester extends Model
         'part',
     ];
 
-    private const SEPARATOR = "-";
+    private const SEPARATOR = '-';
 
     const PARTS = [1, 2];
     const ACTIVE = 'ACTIVE';
@@ -41,17 +40,19 @@ class Semester extends Model
     const END_OF_SPRING_SEMESTER = 7;
     const START_OF_AUTUMN_SEMESTER = 8;
     const END_OF_AUTUMN_SEMESTER = 1;
-    
 
-    public function tag() {
-        return $this->year . self::SEPARATOR . ($this->year + 1) . self::SEPARATOR . $this->part;
+    public function tag()
+    {
+        return $this->year.self::SEPARATOR.($this->year + 1).self::SEPARATOR.$this->part;
     }
 
-    public function isAutumn() {
+    public function isAutumn()
+    {
         return $this->part == 1;
     }
 
-    public function isSpring() {
+    public function isSpring()
+    {
         return $this->part == 2;
     }
 
@@ -82,13 +83,15 @@ class Semester extends Model
         return $this->hasUserWith($user, self::ACTIVE);
     }
 
-    public static function newest() {
+    public static function newest()
+    {
         return Semester::orderBy('year', 'desc')->orderBy('part', 'desc')->first();
     }
 
     // There is always a "current" semester. If there is not in the database, this function creates it.
     // TODO: fine a safer method?
-    public static function current() {
+    public static function current()
+    {
         $now = Carbon::now();
         if ($now->month >= self::START_OF_SPRING_SEMESTER && $now->month < self::END_OF_SPRING_SEMESTER) {
             $part = 2;
@@ -98,6 +101,7 @@ class Semester extends Model
             // This assumes that the semester ends in the new year.
             $year = $now->month <= self::END_OF_AUTUMN_SEMESTER ? $now->year - 1 : $now->year;
         }
+
         return Semester::getOrCreate($year, $part);
     }
 
@@ -110,6 +114,7 @@ class Semester extends Model
             $year = $this->year;
             $part = 2;
         }
+
         return Semester::getOrCreate($year, $part);
     }
 
@@ -127,6 +132,7 @@ class Semester extends Model
             $year = $this->year - 1;
             $part = 2;
         }
+
         return Semester::getOrCreate($year, $part);
     }
 
@@ -144,6 +150,7 @@ class Semester extends Model
                 'part' => $part,
             ]);
         }
+
         return $semester;
     }
 }

--- a/app/Semester.php
+++ b/app/Semester.php
@@ -72,6 +72,16 @@ class Semester extends Model
         return $this->usersWithStatus(self::ACTIVE);
     }
 
+    public function hasUserWith($user, $status)
+    {
+        return $this->usersWithStatus($status)->get()->contains($user);
+    }
+
+    public function isActive($user)
+    {
+        return $this->hasUserWith($user, self::ACTIVE);
+    }
+
     public static function newest() {
         return Semester::orderBy('year', 'desc')->orderBy('part', 'desc')->first();
     }
@@ -88,13 +98,52 @@ class Semester extends Model
             // This assumes that the semester ends in the new year.
             $year = $now->month <= self::END_OF_AUTUMN_SEMESTER ? $now->year - 1 : $now->year;
         }
-        $current_semester = Semester::all()->where('year', $year)->where('part', $part)->first();
-        if ($current_semester === null) {
-            $current_semester = Semester::create([
+        return Semester::getOrCreate($year, $part);
+    }
+
+    public function succ()
+    {
+        if ($this->isSpring()) {
+            $year = $this->year + 1;
+            $part = 1;
+        } else {
+            $year = $this->year;
+            $part = 2;
+        }
+        return Semester::getOrCreate($year, $part);
+    }
+
+    public static function next()
+    {
+        return Semester::current()->succ();
+    }
+
+    public function pred()
+    {
+        if ($this->isSpring()) {
+            $year = $this->year;
+            $part = 1;
+        } else {
+            $year = $this->year - 1;
+            $part = 2;
+        }
+        return Semester::getOrCreate($year, $part);
+    }
+
+    public static function previous()
+    {
+        return Semester::current()->pred();
+    }
+
+    public static function getOrCreate($year, $part)
+    {
+        $semester = Semester::all()->where('year', $year)->where('part', $part)->first();
+        if ($semester === null) {
+            $semester = Semester::create([
                 'year' => $year,
                 'part' => $part,
             ]);
         }
-        return $current_semester;
+        return $semester;
     }
 }

--- a/app/Semester.php
+++ b/app/Semester.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
+
+
+/** A semester is identified by a year and by it's either autumn or spring.
+ * ie. a spring semester starting in february 2020 will be (2019, 2) since we write 2019/20/2.
+ * The autumn semester starting in september 2020 is (2020, 1) since we write 2020/21/1.
+ */
+class Semester extends Model
+{
+    protected $table = 'semesters';
+    protected $primaryKey = 'id';
+    public $incrementing = true;
+    public $timestamps = false;
+    protected $fillable = [
+        'year',
+        'part',
+    ];
+
+    private const SEPARATOR = "-";
+
+    const PARTS = [1, 2];
+    const ACTIVE = 'ACTIVE';
+    const INACTIVE = 'INACTIVE';
+    const PASSIVE = 'PASSIVE';
+    const PENDING = 'PENDING';
+    const STATUSES = [
+        self::ACTIVE,
+        self::INACTIVE,
+        self::PASSIVE,
+        self::PENDING,
+    ];
+
+    // Values are in month
+    // TODO: change to dates?
+    const START_OF_SPRING_SEMESTER = 2;
+    const END_OF_SPRING_SEMESTER = 7;
+    const START_OF_AUTUMN_SEMESTER = 8;
+    const END_OF_AUTUMN_SEMESTER = 1;
+    
+
+    public function tag() {
+        return $this->year . self::SEPARATOR . ($this->year + 1) . self::SEPARATOR . $this->part;
+    }
+
+    public function isAutumn() {
+        return $this->part == 1;
+    }
+
+    public function isSpring() {
+        return $this->part == 2;
+    }
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class, 'semester_status')->withPivot(['status', 'comment']);
+    }
+
+    public function usersWithStatus($status)
+    {
+        return $this->belongsToMany(User::class, 'semester_status')
+                    ->wherePivot('status', '=', $status)
+                    ->withPivot('comment');
+    }
+
+    public function activeUsers()
+    {
+        return $this->usersWithStatus(self::ACTIVE);
+    }
+
+    public static function newest() {
+        return Semester::orderBy('year', 'desc')->orderBy('part', 'desc')->first();
+    }
+
+    // There is always a "current" semester. If there is not in the database, this function creates it.
+    // TODO: fine a safer method?
+    public static function current() {
+        $now = Carbon::now();
+        if ($now->month >= self::START_OF_SPRING_SEMESTER && $now->month < self::END_OF_SPRING_SEMESTER) {
+            $part = 2;
+            $year = $now->year - 1;
+        } else {
+            $part = 1;
+            // This assumes that the semester ends in the new year.
+            $year = $now->month <= self::END_OF_AUTUMN_SEMESTER ? $now->year - 1 : $now->year;
+        }
+        $current_semester = Semester::all()->where('year', $year)->where('part', $part)->first();
+        if ($current_semester === null) {
+            $current_semester = Semester::create([
+                'year' => $year,
+                'part' => $part,
+            ]);
+        }
+        return $current_semester;
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use App\Semester;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -36,6 +37,8 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
     ];
 
+    /* Printing related getters */
+
     public function printAccount()
     {
         return $this->hasOne('App\PrintAccount');
@@ -51,6 +54,13 @@ class User extends Authenticatable
         return $this->hasMany('App\PrintAccountHistory');
     }
 
+    public function printJobs()
+    {
+        return $this->hasMany('App\PrintJob');
+    }
+
+    /* Internet module related getters */
+
     public function internetAccess()
     {
         return $this->hasOne('App\InternetAccess');
@@ -60,6 +70,8 @@ class User extends Authenticatable
     {
         return $this->hasMany('App\MacAddress');
     }
+
+    /* Basic information of the user */
 
     public function personalInformation()
     {
@@ -81,10 +93,7 @@ class User extends Authenticatable
         return $this->belongsToMany(Faculty::class, 'faculty_users');
     }
 
-    public function printJobs()
-    {
-        return $this->hasMany('App\PrintJob');
-    }
+    /* Role related getters */
 
     public function roles()
     {
@@ -101,6 +110,47 @@ class User extends Authenticatable
     public function hasRole(string $roleName, $objectId = null)
     {
         return $this->hasAnyRole([$roleName], $objectId);
+    }
+
+    /* Semester related getters */
+
+    public function allSemesters()
+    {
+        return $this->belongsToMany(Semester::class, 'semester_status')->withPivot(['status', 'comment']);
+    }
+
+    public function semestersWhere($status)
+    {
+        return $this->belongsToMany(Semester::class, 'semester_status')
+                    ->wherePivot('status', '=', $status)
+                    ->withPivot('comment');
+    }
+
+    public function activeSemesters()
+    {
+        return $this->semestersWhere(Semester::ACTIVE);
+    }
+
+    public function isActiveIn($semester)
+    {
+        return $this->activeSemesters->contains($semester);
+    }
+
+    public function isActive()
+    {
+        return $this->isActiveIn(Semester::current());
+    }
+
+    public function getStatusIn($semester)
+    {
+        $semesters = $this->allSemesters;
+        if (!$semesters->contains($semester)) return Semester::INACTIVE;
+        return $semesters->find($semester)->pivot->status;
+    }
+
+    public function getStatus()
+    {
+        return getStatusIn(Semester::current());
     }
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -2,7 +2,6 @@
 
 namespace App;
 
-use App\Semester;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -144,7 +143,10 @@ class User extends Authenticatable
     public function getStatusIn($semester)
     {
         $semesters = $this->allSemesters;
-        if (!$semesters->contains($semester)) return Semester::INACTIVE;
+        if (! $semesters->contains($semester)) {
+            return Semester::INACTIVE;
+        }
+
         return $semesters->find($semester)->pivot->status;
     }
 

--- a/database/migrations/2020_06_03_173354_create_semester_table.php
+++ b/database/migrations/2020_06_03_173354_create_semester_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSemesterTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('semesters', function (Blueprint $table) {
+            // Eloquent does not support composite primary keys, so let's just add one there.
+            $table->smallIncrements('id');
+            $table->unsignedInteger('year');
+            $table->set('part', \App\Semester::PARTS);
+        });
+        
+        Schema::create('semester_status', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedSmallInteger('semester_id');
+            $table->set('status', \App\Semester::STATUSES)->default(\App\Semester::ACTIVE);
+            $table->text('comment')->nullable();
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('semester_id')->references('id')->on('semesters')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('semester_status', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropForeign(['semester_id']);
+        });
+        Schema::dropIfExists('semesters');        
+        Schema::dropIfExists('semester_status');
+    }
+}

--- a/database/migrations/2020_06_03_173354_create_semester_table.php
+++ b/database/migrations/2020_06_03_173354_create_semester_table.php
@@ -19,7 +19,7 @@ class CreateSemesterTable extends Migration
             $table->unsignedInteger('year');
             $table->set('part', \App\Semester::PARTS);
         });
-        
+
         Schema::create('semester_status', function (Blueprint $table) {
             $table->unsignedBigInteger('user_id');
             $table->unsignedSmallInteger('semester_id');
@@ -42,7 +42,7 @@ class CreateSemesterTable extends Migration
             $table->dropForeign(['user_id']);
             $table->dropForeign(['semester_id']);
         });
-        Schema::dropIfExists('semesters');        
+        Schema::dropIfExists('semesters');
         Schema::dropIfExists('semester_status');
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         $this->call(UsersTableSeeder::class);
+        $this->call(SemesterSeeder::class);
     }
 }

--- a/database/seeds/SemesterSeeder.php
+++ b/database/seeds/SemesterSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class SemesterSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // TODO: there could be more semesters
+        $semester = \App\Semester::create([
+            'year' => 2019,
+            'part' => 2
+        ]);
+
+        $users = \App\User::all();
+
+        //TODO: this could be more random
+        foreach ($users as $key => $user) {
+            $user->allSemesters()->attach($semester, ['status' => \App\Semester::ACTIVE]);
+        }
+    }
+}

--- a/database/seeds/SemesterSeeder.php
+++ b/database/seeds/SemesterSeeder.php
@@ -14,7 +14,7 @@ class SemesterSeeder extends Seeder
         // TODO: there could be more semesters
         $semester = \App\Semester::create([
             'year' => 2019,
-            'part' => 2
+            'part' => 2,
         ]);
 
         $users = \App\User::all();

--- a/routes/web.php
+++ b/routes/web.php
@@ -64,4 +64,7 @@ Route::middleware(['auth', 'log', 'verified'])->group(function () {
     Route::get('/faults/table', 'FaultsController@GetFaultsTable')->name('faults.table');
     Route::post('/faults/add', 'FaultsController@addFault')->name('faults.add');
     Route::post('/faults/update', 'FaultsController@updateStatus')->name('faults.update');
+
+
+    Route::get('/secretariat/users', 'SecretariatController@list')->name('secretariat.users');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,6 +65,5 @@ Route::middleware(['auth', 'log', 'verified'])->group(function () {
     Route::post('/faults/add', 'FaultsController@addFault')->name('faults.add');
     Route::post('/faults/update', 'FaultsController@updateStatus')->name('faults.update');
 
-
     Route::get('/secretariat/users', 'SecretariatController@list')->name('secretariat.users');
 });


### PR DESCRIPTION
Fixes #200.

This PR lays down the ground work for tracking the status of the students.  It contains the basic logic of semesters with a few getters. Users can be attached a status, currently I chose active, inactive, passive and pending. The status "passive" is someone with passive status or at Erasmus, etc. The idea behind "pending" comes from the statement we just had to fill; if someone fills it with the option to write a petition, their status for the next semester could be set to it, so we can track who filled it and who did not. It also provides some data we can work with.

The size of the PR is kept down on purpose. That way it's easier to review and build on. Some TODOs:
 - properly generate new semesters
 - make the seeder more random
 - define the beginning/end of semester more finely?
 - UI
 - permissions

The PR now enables the followings (just a few things that came to my mind):
 - Automatically set the status of students to active on registration, inactive at the end of each semester. That way students could fill the statement like when they log in at Neptun.
 - Attach room and classroom assignments to semesters.
 - Notify teachers about filling the subject list.
 - etc...

When the PR gets merged, I'll open the issues accordingly.