### PR TITLE
Backend for tracking collegist status

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,8 +24,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')
-        //          ->hourly();
+        $schedule->call(EventTrigger::listen)->hourly();
     }
 
     /**

--- a/app/EventTrigger.php
+++ b/app/EventTrigger.php
@@ -39,11 +39,32 @@ class EventTrigger extends Model
         self::DEACTIVATE_STATUS_SIGNAL,
     ];
 
+    public static function listen()
+    {
+        $now = Carbon::now();
+        $events = EventTrigger::where('date', '<=', $now)
+                              ->where('date', '>', $now->subHours(1));
+        foreach ($events as $event) {
+            $event->handleSignal();
+        }
+        return $events;
+    }
+
     /* Getters */
 
-    public static function getInternetActivationDeadline()
+    public static function internetActivationDeadline()
     {
         return self::find(INTERNET_ACTIVATION_SIGNAL)->data;
+    }
+
+    public static function statementRequestDate()
+    {
+        return self::find(SEND_STATUS_STATEMENT_REQUEST)->date;
+    }
+
+    public static function statementDeadline()
+    {
+        return self::find(DEACTIVATE_STATUS_SIGNAL)->date;
     }
 
     /* Handlers which are fired when the set date is reached. */

--- a/app/EventTrigger.php
+++ b/app/EventTrigger.php
@@ -3,7 +3,6 @@
 namespace App;
 
 use App\Http\Controllers\SecretariatController;
-use App\Semester;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Log;
@@ -52,6 +51,7 @@ class EventTrigger extends Model
         foreach ($events as $event) {
             $event->handleSignal();
         }
+
         return $events;
     }
 
@@ -86,10 +86,11 @@ class EventTrigger extends Model
             case self::DEACTIVATE_STATUS_SIGNAL:
                 $this->deactivateStatus();
                 break;
-            default:        
-                Log::warning("Event Trigger got undefined signal: " . $this->signal);
+            default:
+                Log::warning('Event Trigger got undefined signal: '.$this->signal);
                 break;
         }
+
         return $this;
     }
 
@@ -119,7 +120,7 @@ class EventTrigger extends Model
             'date' => $current_date->addMonth($months_to_add),
         ]);
     }
-    
+
     private function deactivateStatus()
     {
         $months_to_add = Semester::current()->isSpring() ? 7 : 5;

--- a/app/EventTrigger.php
+++ b/app/EventTrigger.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App;
+
+use App\Semester;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * This class implements the logic of triggering certain events (eg. automatic status changes)
+ * when we reach a given datetime. The triggers will fire a signal that we handle accordingly.
+ * Members of this models should not get created through the site. It is stored in the database
+ * so the dates can be changed on the run, everything else should be static.
+ */
+class EventTrigger extends Model
+{
+    public $timestamps = false;
+    public $incrementing = false;
+    protected $primaryKey = 'signal';
+    protected $fillable = [
+        'name', 'data', 'date', 'signal', 'comment',
+    ];
+
+    protected $casts = [
+        'date' => 'datetime',
+    ];
+
+    const INTERNET_ACTIVATION_SIGNAL = 0;
+    const SEND_STATUS_STATEMENT_REQUEST = 1;
+    const DEACTIVATE_STATUS = 2;
+    const SIGNALS = [
+        self::INTERNET_ACTIVATION_SIGNAL,
+        self::SEND_STATUS_STATEMENT_REQUEST,
+        self::DEACTIVATE_STATUS,
+    ];
+
+    /* Handlers which are fired when the set date is reached. */
+
+    public function handleSignal()
+    {
+        switch ($this->signal) {
+            case self::INTERNET_ACTIVATION_SIGNAL:
+                $this->handleInternetActivationSignal();
+                break;
+            case self::SEND_STATUS_STATEMENT_REQUEST:
+                $this->handleSendStatusStatementRequest();
+                break;
+            case self::DEACTIVATE_STATUS:
+                $this->deactivateStatus();
+                break;
+            default:        
+                Log::warning("Event Trigger got undefined signal: " . $this->signal);
+                break;
+        }
+        return $this;
+    }
+
+    private function handleInternetActivationSignal() {
+        $months_to_add = Semester::current()->isSpring() ? 7 : 5;
+        $current_date = Carbon::instance($this->date);
+        $current_data = Carbon::parse($this->data);
+        $this->update([
+            // Update the new trigger date
+            'date' => $current_date->addMonth($months_to_add),
+            // Update the new activation deadline
+            'data' => $current_data->addMonth($months_to_add),
+        ]);
+    }
+
+    private function handleSendStatusStatementRequest() {
+
+    }
+    
+    private function deactivateStatus() {
+
+    }
+}

--- a/app/EventTrigger.php
+++ b/app/EventTrigger.php
@@ -30,8 +30,13 @@ class EventTrigger extends Model
         'date' => 'datetime',
     ];
 
+    // Signal for setting the default activation date to the next semester.
     const INTERNET_ACTIVATION_SIGNAL = 0;
+    // Signal for notifying the students to make a statement regarding their status
+    // in the next semester.
     const SEND_STATUS_STATEMENT_REQUEST = 1;
+    // Deadline for the above signal; when triggered, everyone who did not make a
+    // statement will be set to inactive.
     const DEACTIVATE_STATUS_SIGNAL = 2;
     const SIGNALS = [
         self::INTERNET_ACTIVATION_SIGNAL,

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -7,6 +7,7 @@ use App\Faculty;
 use App\Http\Controllers\Controller;
 use App\PersonalInformation;
 use App\Role;
+use App\Semester;
 use App\User;
 use App\Workshop;
 use Illuminate\Foundation\Auth\RegistersUsers;
@@ -147,6 +148,7 @@ class RegisterController extends Controller
                 foreach ($data['workshop'] as $key => $workshop) {
                     $user->workshops()->attach($workshop);
                 }
+                $user->setStatus(Semester::ACTIVE, "Activated through registration");
                 break;
             default:
                 throw new AuthorizationException();

--- a/app/Http/Controllers/SecretariatController.php
+++ b/app/Http/Controllers/SecretariatController.php
@@ -8,6 +8,7 @@ class SecretariatController extends Controller
 {
     public function list()
     {
+        return \App\EventTrigger::first()->handleSignal();
         return Semester::current()->activeUsers;
     }
 }

--- a/app/Http/Controllers/SecretariatController.php
+++ b/app/Http/Controllers/SecretariatController.php
@@ -10,7 +10,7 @@ class SecretariatController extends Controller
 {
     public function list()
     {
-        return Semester::current()->activeUsers()->get();
+        return Semester::current()->activeUsers;
     }
 
     public static function isStatementAvailable()

--- a/app/Http/Controllers/SecretariatController.php
+++ b/app/Http/Controllers/SecretariatController.php
@@ -36,10 +36,9 @@ class SecretariatController extends Controller
         $users = User::all();
         $next_semester = Semester::next();
         foreach ($users as $user) {
-            if (!$user->isInSemester($next_semester)) {
-                $user->setStatusFor($next_semester, Semester::INACTIVE, "Failed to make a statement");
+            if (! $user->isInSemester($next_semester)) {
+                $user->setStatusFor($next_semester, Semester::INACTIVE, 'Failed to make a statement');
             }
         }
     }
-
 }

--- a/app/Http/Controllers/SecretariatController.php
+++ b/app/Http/Controllers/SecretariatController.php
@@ -11,4 +11,15 @@ class SecretariatController extends Controller
         return \App\EventTrigger::first()->handleSignal();
         return Semester::current()->activeUsers;
     }
+
+    public static function sendStatementMail()
+    {
+        //TODO
+    }
+
+    public static function finalizeStatements()
+    {
+        //TODO
+    }
+
 }

--- a/app/Semester.php
+++ b/app/Semester.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 /** A semester is identified by a year and by it's either autumn or spring.
  * ie. a spring semester starting in february 2020 will be (2019, 2) since we write 2019/20/2.
  * The autumn semester starting in september 2020 is (2020, 1) since we write 2020/21/1.
- * 
+ *
  * The status can be verified or not (by default it is not). Users with permission has to
  * confirm that the user can have the given status.
  */

--- a/app/Semester.php
+++ b/app/Semester.php
@@ -8,6 +8,9 @@ use Illuminate\Database\Eloquent\Model;
 /** A semester is identified by a year and by it's either autumn or spring.
  * ie. a spring semester starting in february 2020 will be (2019, 2) since we write 2019/20/2.
  * The autumn semester starting in september 2020 is (2020, 1) since we write 2020/21/1.
+ * 
+ * The status can be verified or not (by default it is not). Users with permission has to
+ * confirm that the user can have the given status.
  */
 class Semester extends Model
 {
@@ -41,6 +44,7 @@ class Semester extends Model
     const START_OF_AUTUMN_SEMESTER = 8;
     const END_OF_AUTUMN_SEMESTER = 1;
 
+    // For displaying semesters
     public function tag()
     {
         return $this->year.self::SEPARATOR.($this->year + 1).self::SEPARATOR.$this->part;
@@ -58,14 +62,14 @@ class Semester extends Model
 
     public function users()
     {
-        return $this->belongsToMany(User::class, 'semester_status')->withPivot(['status', 'comment']);
+        return $this->belongsToMany(User::class, 'semester_status')->withPivot(['status', 'verified', 'comment']);
     }
 
     public function usersWithStatus($status)
     {
         return $this->belongsToMany(User::class, 'semester_status')
                     ->wherePivot('status', '=', $status)
-                    ->withPivot('comment');
+                    ->withPivot('comment', 'verified');
     }
 
     public function activeUsers()

--- a/app/User.php
+++ b/app/User.php
@@ -168,6 +168,7 @@ class User extends Authenticatable
                 'comment' => $comment,
             ],
         ]);
+
         return $this;
     }
 
@@ -183,9 +184,10 @@ class User extends Authenticatable
                 'verify' => true,
             ],
         ]);
+
         return $this;
     }
-    
+
     /**
      * @deprecated use hasRole instead
      */

--- a/app/User.php
+++ b/app/User.php
@@ -115,14 +115,14 @@ class User extends Authenticatable
 
     public function allSemesters()
     {
-        return $this->belongsToMany(Semester::class, 'semester_status')->withPivot(['status', 'comment']);
+        return $this->belongsToMany(Semester::class, 'semester_status')->withPivot(['status', 'verified', 'comment']);
     }
 
     public function semestersWhere($status)
     {
         return $this->belongsToMany(Semester::class, 'semester_status')
                     ->wherePivot('status', '=', $status)
-                    ->withPivot('comment');
+                    ->withPivot('verified', 'comment');
     }
 
     public function activeSemesters()
@@ -166,7 +166,7 @@ class User extends Authenticatable
             $semester->id => [
                 'status' => $status,
                 'comment' => $comment,
-            ]
+            ],
         ]);
         return $this;
     }
@@ -176,6 +176,16 @@ class User extends Authenticatable
         return $this->setStatusFor(Semester::current(), $status, $comment);
     }
 
+    public function verify($semester)
+    {
+        $this->allSemesters()->syncWithoutDetaching([
+            $semester->id => [
+                'verify' => true,
+            ],
+        ]);
+        return $this;
+    }
+    
     /**
      * @deprecated use hasRole instead
      */

--- a/app/User.php
+++ b/app/User.php
@@ -130,6 +130,11 @@ class User extends Authenticatable
         return $this->semestersWhere(Semester::ACTIVE);
     }
 
+    public function isInSemester($semester)
+    {
+        return $this->allSemesters->contains($semester);
+    }
+
     public function isActiveIn($semester)
     {
         return $this->activeSemesters->contains($semester);
@@ -153,6 +158,22 @@ class User extends Authenticatable
     public function getStatus()
     {
         return getStatusIn(Semester::current());
+    }
+
+    public function setStatusFor($semester, $status, $comment = null)
+    {
+        $this->allSemesters()->syncWithoutDetaching([
+            $semester->id => [
+                'status' => $status,
+                'comment' => $comment,
+            ]
+        ]);
+        return $this;
+    }
+
+    public function setStatus($status, $comment = null)
+    {
+        return $this->setStatusFor(Semester::current(), $status, $comment);
     }
 
     /**

--- a/database/migrations/2020_06_09_104537_create_event_triggers_table.php
+++ b/database/migrations/2020_06_09_104537_create_event_triggers_table.php
@@ -24,6 +24,11 @@ class CreateEventTriggersTable extends Migration
             
             $table->primary('signal');
         });
+
+        Schema::table('semesters', function (Blueprint $table) {
+            $table->boolean('verified')->default(false);
+        });
+
         EventTrigger::create([
             'name' => 'internet_valid_until',
             'data' => Carbon::createFromDate(2020, 3, 15, 'Europe/Budapest'),
@@ -31,12 +36,14 @@ class CreateEventTriggersTable extends Migration
             'signal' => EventTrigger::INTERNET_ACTIVATION_SIGNAL,
             'comment' => 'When the date is reached, activating internet will have new default value',
         ]);
+
         EventTrigger::create([
             'name' => 'internet_valid_until',
             'date' => Carbon::createFromDate(2020, 6, 1, 'Europe/Budapest'),
             'signal' => EventTrigger::SEND_STATUS_STATEMENT_REQUEST,
             'comment' => 'The trigger to nofify students about filling out statements regarding their status in the next semester',
         ]);
+
         EventTrigger::create([
             'name' => 'internet_valid_until',
             'date' => Carbon::createFromDate(2020, 6, 15, 'Europe/Budapest'),

--- a/database/migrations/2020_06_09_104537_create_event_triggers_table.php
+++ b/database/migrations/2020_06_09_104537_create_event_triggers_table.php
@@ -17,7 +17,7 @@ class CreateEventTriggersTable extends Migration
     {
         Schema::create('event_triggers', function (Blueprint $table) {
             $table->text('name');
-            $table->text('data');
+            $table->text('data')->nullable();
             $table->timestamp('date');
             $table->integer('signal');
             $table->text('comment')->nullable();
@@ -30,6 +30,18 @@ class CreateEventTriggersTable extends Migration
             'date' => Carbon::createFromDate(2020, 2, 1, 'Europe/Budapest'),
             'signal' => EventTrigger::INTERNET_ACTIVATION_SIGNAL,
             'comment' => 'When the date is reached, activating internet will have new default value',
+        ]);
+        EventTrigger::create([
+            'name' => 'internet_valid_until',
+            'date' => Carbon::createFromDate(2020, 6, 1, 'Europe/Budapest'),
+            'signal' => EventTrigger::SEND_STATUS_STATEMENT_REQUEST,
+            'comment' => 'The trigger to nofify students about filling out statements regarding their status in the next semester',
+        ]);
+        EventTrigger::create([
+            'name' => 'internet_valid_until',
+            'date' => Carbon::createFromDate(2020, 6, 15, 'Europe/Budapest'),
+            'signal' => EventTrigger::DEACTIVATE_STATUS_SIGNAL,
+            'comment' => 'The date when all students who did not make the above statement will lose their status for the next semester',
         ]);
     }
 

--- a/database/migrations/2020_06_09_104537_create_event_triggers_table.php
+++ b/database/migrations/2020_06_09_104537_create_event_triggers_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\EventTrigger;
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateEventTriggersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('event_triggers', function (Blueprint $table) {
+            $table->text('name');
+            $table->text('data');
+            $table->timestamp('date');
+            $table->integer('signal');
+            $table->text('comment')->nullable();
+            
+            $table->primary('signal');
+        });
+        EventTrigger::create([
+            'name' => 'internet_valid_until',
+            'data' => Carbon::createFromDate(2020, 3, 15, 'Europe/Budapest'),
+            'date' => Carbon::createFromDate(2020, 2, 1, 'Europe/Budapest'),
+            'signal' => EventTrigger::INTERNET_ACTIVATION_SIGNAL,
+            'comment' => 'When the date is reached, activating internet will have new default value',
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('event_triggers');
+    }
+}

--- a/database/migrations/2020_06_09_104537_create_event_triggers_table.php
+++ b/database/migrations/2020_06_09_104537_create_event_triggers_table.php
@@ -21,7 +21,7 @@ class CreateEventTriggersTable extends Migration
             $table->timestamp('date');
             $table->integer('signal');
             $table->text('comment')->nullable();
-            
+
             $table->primary('signal');
         });
 

--- a/database/migrations/2020_06_09_104537_create_event_triggers_table.php
+++ b/database/migrations/2020_06_09_104537_create_event_triggers_table.php
@@ -59,6 +59,9 @@ class CreateEventTriggersTable extends Migration
      */
     public function down()
     {
+        Schema::table('semesters', function (Blueprint $table) {
+            $table->dropColumn('verified');
+        });
         Schema::dropIfExists('event_triggers');
     }
 }


### PR DESCRIPTION
Added the logic of triggers. We listen to them hourly and handle them when the given time is reached. These triggers should be added only through migration. Created a database for them so the dates of the triggers can be customized.

Currently implemented 3 triggers (I'm open to better names):
 - INTERNET_ACTIVATION_SIGNAL: Signal for setting the default activation date to the next semester.
 - SEND_STATUS_STATEMENT_REQUEST: Signal for notifying the students to make a statement regarding their status in the next semester.
 - DEACTIVATE_STATUS_SIGNAL: Deadline for the above signal; when triggered, everyone who did not make a statement will be set to inactive.

Regarding the statuses: implemented backend for handling the statements and setting the statuses. When the students make the statement, it should be unverified, someone with the appropriate permissions should verify their status.
