### PR TITLE
Fix PrintAccount History bug

### DIFF
--- a/database/migrations/2020_02_22_093459_create_print_account_history_table.php
+++ b/database/migrations/2020_02_22_093459_create_print_account_history_table.php
@@ -26,6 +26,7 @@ class CreatePrintAccountHistoryTable extends Migration
             $table->unsignedBigInteger('modified_by');
             $table->timestamp('modified_at');
         });
+        // This triggers is changed in fix_trigger migrations.
         DB::unprepared('
             CREATE TRIGGER trigger_print_account_history_balance
             AFTER UPDATE ON print_accounts
@@ -38,6 +39,7 @@ class CreatePrintAccountHistoryTable extends Migration
                     modified_by)
                 VALUES(OLD.user_id, NEW.balance - OLD.balance, 0, NULL, NEW.last_modified_by);
         ');
+
         DB::unprepared('
             CREATE TRIGGER trigger_update_print_account_history_free_pages
             AFTER UPDATE ON printing_free_pages
@@ -54,6 +56,7 @@ class CreatePrintAccountHistoryTable extends Migration
                     VALUES(OLD.user_id, 0, NEW.amount, @new_deadline, NEW.last_modified_by, NEW.updated_at);
                 END;
         ');
+
         DB::unprepared('
             CREATE TRIGGER trigger_insert_print_account_history_free_pages
             AFTER INSERT ON printing_free_pages

--- a/database/migrations/2020_06_12_102943_fix_trigger.php
+++ b/database/migrations/2020_06_12_102943_fix_trigger.php
@@ -1,8 +1,6 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
 class FixTrigger extends Migration
 {

--- a/database/migrations/2020_06_12_102943_fix_trigger.php
+++ b/database/migrations/2020_06_12_102943_fix_trigger.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class FixTrigger extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::Unprepared('DROP TRIGGER IF EXISTS trigger_print_account_history_balance');
+
+        DB::unprepared('
+            CREATE TRIGGER trigger_print_account_history_balance
+            AFTER UPDATE ON print_accounts
+            FOR EACH ROW
+                BEGIN
+                    IF (NEW.balance <> OLD.balance) THEN
+                        INSERT INTO print_account_history(
+                            user_id,
+                            balance_change,
+                            free_page_change,
+                            deadline_change,
+                            modified_by)
+                        VALUES(OLD.user_id, NEW.balance - OLD.balance, 0, NULL, NEW.last_modified_by);
+                    END IF;
+                END;
+        ');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //We will drop these later.
+    }
+}


### PR DESCRIPTION
The trigger was fired when the last modifier was changed, inserting an extra line unnecessarily.

Solved by adding a condition in the trigger.