### PR TITLE
Fix bug: Unable to modify internet access close to the actual date

### DIFF
--- a/app/EventTrigger.php
+++ b/app/EventTrigger.php
@@ -59,17 +59,17 @@ class EventTrigger extends Model
 
     public static function internetActivationDeadline()
     {
-        return self::find(INTERNET_ACTIVATION_SIGNAL)->data;
+        return self::find(self::INTERNET_ACTIVATION_SIGNAL)->data;
     }
 
     public static function statementRequestDate()
     {
-        return self::find(SEND_STATUS_STATEMENT_REQUEST)->date;
+        return self::find(self::SEND_STATUS_STATEMENT_REQUEST)->date;
     }
 
     public static function statementDeadline()
     {
-        return self::find(DEACTIVATE_STATUS_SIGNAL)->date;
+        return self::find(self::DEACTIVATE_STATUS_SIGNAL)->date;
     }
 
     /* Handlers which are fired when the set date is reached. */

--- a/app/Http/Controllers/InternetController.php
+++ b/app/Http/Controllers/InternetController.php
@@ -27,7 +27,7 @@ class InternetController extends Controller
 
     public function admin()
     {
-        $activationDate = env('INTERNET_ACTIVATION_DATE'); //TODO: get date for current semester
+        $activationDate = \App\EventTrigger::internetActivationDeadline();
 
         return view('admin.internet.app', ['activation_date' => $activationDate, 'users' => User::all()]);
     }

--- a/database/migrations/2020_06_09_104537_create_event_triggers_table.php
+++ b/database/migrations/2020_06_09_104537_create_event_triggers_table.php
@@ -31,22 +31,22 @@ class CreateEventTriggersTable extends Migration
 
         EventTrigger::create([
             'name' => 'internet_valid_until',
-            'data' => Carbon::createFromDate(2020, 3, 15, 'Europe/Budapest'),
-            'date' => Carbon::createFromDate(2020, 2, 1, 'Europe/Budapest'),
+            'data' => Carbon::createFromDate(2020, 10, 15, 'Europe/Budapest'),
+            'date' => Carbon::createFromDate(2020, 9, 1, 'Europe/Budapest'),
             'signal' => EventTrigger::INTERNET_ACTIVATION_SIGNAL,
             'comment' => 'When the date is reached, activating internet will have new default value',
         ]);
 
         EventTrigger::create([
-            'name' => 'internet_valid_until',
-            'date' => Carbon::createFromDate(2020, 6, 1, 'Europe/Budapest'),
+            'name' => 'send_status_statement_request',
+            'date' => Carbon::createFromDate(2021, 1, 1, 'Europe/Budapest'),
             'signal' => EventTrigger::SEND_STATUS_STATEMENT_REQUEST,
             'comment' => 'The trigger to nofify students about filling out statements regarding their status in the next semester',
         ]);
 
         EventTrigger::create([
-            'name' => 'internet_valid_until',
-            'date' => Carbon::createFromDate(2020, 6, 15, 'Europe/Budapest'),
+            'name' => 'deactivate_status_signal',
+            'date' => Carbon::createFromDate(2021, 1, 15, 'Europe/Budapest'),
             'signal' => EventTrigger::DEACTIVATE_STATUS_SIGNAL,
             'comment' => 'The date when all students who did not make the above statement will lose their status for the next semester',
         ]);

--- a/resources/views/admin/internet/internet_access/internet_access.blade.php
+++ b/resources/views/admin/internet/internet_access/internet_access.blade.php
@@ -15,7 +15,7 @@
                 .add($("<button class=\"btn waves-effect\">@lang('internet.deactivate')</button>")
                     .click(function () {
                         saveData(cell, {...data, has_internet_until: null});
-                    }).toggle(data.has_internet_until != null && active > now)).wrapAll('<div></div>').parent()[0];
+                    }).toggle(data.has_internet_until != null && active >= now)).wrapAll('<div></div>').parent()[0];
         };
 
         var saveData = function(cell, data = null) {


### PR DESCRIPTION
This is mostly fixed with the new EventTrigger system. This will automatically updates the internet activation date, so the condition can always be true when needed.