### PR TITLE
Fix print history bug

### DIFF
--- a/app/Console/Commands.php
+++ b/app/Console/Commands.php
@@ -20,7 +20,8 @@ class Commands
         if (self::isDebugMode()) {
             $result = [0];
         } else {
-            $result = exec("lpstat -W completed -o " . config('print.printer_name') . " | awk '{print $1}'", $result);
+            $result = [];
+            exec("lpstat -W completed -o " . config('print.printer_name') . " | awk '{print $1}'", $result);
         }
         return $result;
     }

--- a/app/Http/Controllers/PrintController.php
+++ b/app/Http/Controllers/PrintController.php
@@ -218,9 +218,13 @@ class PrintController extends Controller
     /** Private helper functions */
 
     private function updateCompletedPrintingJobs() {
-        $result = Commands::updateCompletedPrintingJobs();
-        Log::info("Completed jobs: " . implode(', ', $result));
-        PrintJob::whereIn('job_id', $result)->update(['state' => PrintJob::SUCCESS]);
+        try {
+            $result = Commands::updateCompletedPrintingJobs();
+            Log::info("Completed jobs: " . implode(', ', $result));
+            PrintJob::whereIn('job_id', $result)->update(['state' => PrintJob::SUCCESS]);
+        } catch (\Exception $e) {
+            Log::error("Printing error at line: " . __FILE__ . ":" . __LINE__ . " (in function " . __FUNCTION__ . "). " . $e->getMessage());
+        }
     }
 
     private function storeFile($file)


### PR DESCRIPTION
Two things are done:
- Changing the return value of the exec call, it should now properly return all jobs, not just the last line (see [PHP exec doc](https://www.php.net/manual/en/function.exec.php))
- adding a try cache block, since anything could go wrong with an exec call

Hopefully fixes #281 