### PR TITLE
Default locale set to hungarian for mailables

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -2,10 +2,11 @@
 
 namespace App;
 
+use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-class User extends Authenticatable
+class User extends Authenticatable implements HasLocalePreference
 {
     use Notifiable;
 
@@ -35,6 +36,17 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    /**
+     * Get the user's preferred locale.
+     *
+     * @return string
+     */
+    public function preferredLocale()
+    {
+        //TODO store preferred locale for each user
+        return 'hu';
+    }
 
     /* Printing related getters */
 


### PR DESCRIPTION
Temporary solution for #318

With `HasLocalePreference` interface, all the mailables will use the locale set in User model's `preferredLocale()` function.
However, we still need to store the preferred locale for every user.
For now, I have set the default locale to hungarian,