### PR TITLE
Fix Facade not found error

### DIFF
--- a/app/Http/Controllers/EmailController.php
+++ b/app/Http/Controllers/EmailController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use App\User;
-use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Mail;
 
 class EmailController extends Controller
 {


### PR DESCRIPTION
Even thought the File facade is defined as an alias in the config files, I am seeing these lines in the logs:

`[2020-09-03 20:21:29] testing.ERROR: Class 'App\Http\Controllers\File' not found {"userId":37,"exception":"[object] (Error(code: 0): Class 'App\\Http\\Controllers\\File' not found at /Users/norbertluksa/mars/app/Http/Controllers/EmailController.php:16)
`

Maybe there are some problems because it's used in mails, but I added the fully qualified namespaces just to be safe.