### PR TITLE
Query optimizations

### DIFF
--- a/app/Http/Controllers/Secretariat/UserController.php
+++ b/app/Http/Controllers/Secretariat/UserController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Secretariat;
 
 use App\Http\Controllers\Controller;
+use App\Models\Role;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -114,7 +115,8 @@ class UserController extends Controller
     public function list()
     {
         $this->authorize('viewAny', User::class);
-        $users = User::collegists()->sortBy('name');
+        $users = User::role(Role::COLLEGIST)
+            ->with(['roles', 'workshops', 'educationalInformation', 'allSemesters'])->orderBy('name')->get();
 
         return view('secretariat.user.list')->with('users', $users);
     }

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -102,9 +102,10 @@ class Role extends Model
     public static function possibleObjectsFor($name)
     {
         if (in_array($name, [self::WORKSHOP_ADMINISTRATOR, self::WORKSHOP_LEADER])) {
-            if(!Cache::get('workshop.all')) {
+            if(! Cache::get('workshop.all')) {
                 Cache::put('workshop.all', Workshop::all(), 60);
             }
+
             return Cache::get('workshop.all');
         }
         if ($name == self::LOCALE_ADMIN) {

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -102,7 +102,7 @@ class Role extends Model
     public static function possibleObjectsFor($name)
     {
         if (in_array($name, [self::WORKSHOP_ADMINISTRATOR, self::WORKSHOP_LEADER])) {
-            if(! Cache::get('workshop.all')) {
+            if (! Cache::get('workshop.all')) {
                 Cache::put('workshop.all', Workshop::all(), 60);
             }
 

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
 
 class Role extends Model
 {
@@ -101,7 +102,10 @@ class Role extends Model
     public static function possibleObjectsFor($name)
     {
         if (in_array($name, [self::WORKSHOP_ADMINISTRATOR, self::WORKSHOP_LEADER])) {
-            return Workshop::all();
+            if(!Cache::get('workshop.all')) {
+                Cache::put('workshop.all', Workshop::all(), 60);
+            }
+            return Cache::get('workshop.all');
         }
         if ($name == self::LOCALE_ADMIN) {
             // Do we have this somewhere?

--- a/app/Models/Semester.php
+++ b/app/Models/Semester.php
@@ -153,8 +153,8 @@ class Semester extends Model
     // There is always a "current" semester. If there is not in the database, this function creates it.
     public static function current()
     {
-        $today = Carbon::today();
-        if (! Cache::get('semester.current.' . $today)) {
+        $today = Carbon::today()->format('Ymd');
+        if (! Cache::get('semester.current.'.$today)) {
             $now = Carbon::now();
             if ($now->month >= self::START_OF_SPRING_SEMESTER && $now->month <= self::END_OF_SPRING_SEMESTER) {
                 $part = 2;
@@ -167,10 +167,10 @@ class Semester extends Model
 
             $current = Semester::getOrCreate($year, $part);
 
-            Cache::put('semester.current.' . $today, $current, 86400);
+            Cache::put('semester.current.'.$today, $current, 86400);
         }
 
-        return Cache::get('semester.current.' . $today);
+        return Cache::get('semester.current.'.$today);
     }
 
     public function isCurrent()

--- a/app/Models/Semester.php
+++ b/app/Models/Semester.php
@@ -153,7 +153,7 @@ class Semester extends Model
     // There is always a "current" semester. If there is not in the database, this function creates it.
     public static function current()
     {
-        if(!Cache::get('semester.current')) {
+        if(! Cache::get('semester.current')) {
             $now = Carbon::now();
             if ($now->month >= self::START_OF_SPRING_SEMESTER && $now->month <= self::END_OF_SPRING_SEMESTER) {
                 $part = 2;

--- a/app/Models/Semester.php
+++ b/app/Models/Semester.php
@@ -153,7 +153,7 @@ class Semester extends Model
     // There is always a "current" semester. If there is not in the database, this function creates it.
     public static function current()
     {
-        if(! Cache::get('semester.current')) {
+        if (! Cache::get('semester.current')) {
             $now = Carbon::now();
             if ($now->month >= self::START_OF_SPRING_SEMESTER && $now->month <= self::END_OF_SPRING_SEMESTER) {
                 $part = 2;

--- a/app/Models/Semester.php
+++ b/app/Models/Semester.php
@@ -153,7 +153,8 @@ class Semester extends Model
     // There is always a "current" semester. If there is not in the database, this function creates it.
     public static function current()
     {
-        if (! Cache::get('semester.current')) {
+        $today = Carbon::today();
+        if (! Cache::get('semester.current.' . $today)) {
             $now = Carbon::now();
             if ($now->month >= self::START_OF_SPRING_SEMESTER && $now->month <= self::END_OF_SPRING_SEMESTER) {
                 $part = 2;
@@ -166,10 +167,10 @@ class Semester extends Model
 
             $current = Semester::getOrCreate($year, $part);
 
-            Cache::put('semester.current', $current, 3600);
+            Cache::put('semester.current.' . $today, $current, 86400);
         }
 
-        return Cache::get('semester.current');
+        return Cache::get('semester.current.' . $today);
     }
 
     public function isCurrent()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -209,7 +209,7 @@ class User extends Authenticatable implements HasLocalePreference
 
     public function scopeRole($query, $role)
     {
-        return $query->whereHas('roles', function($q) use ($role) {
+        return $query->whereHas('roles', function ($q) use ($role) {
             $q->name = $role;
         });
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -210,7 +210,7 @@ class User extends Authenticatable implements HasLocalePreference
     public function scopeRole($query, $role)
     {
         return $query->whereHas('roles', function ($q) use ($role) {
-            $q->name = $role;
+            $q->where('name', $role);
         });
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -207,6 +207,13 @@ class User extends Authenticatable implements HasLocalePreference
         return false;
     }
 
+    public function scopeRole($query, $role)
+    {
+        return $query->whereHas('roles', function($q) use ($role) {
+            $q->name = $role;
+        });
+    }
+
     // Has any role with all possible object ID
     public function hasRoleBase(string $roleName)
     {


### PR DESCRIPTION
I wanted to fix the user order issue (#427), but I saw that that the user management page makes lots of unnecessary queries. With the seeded data it was nearly 500 queries, now it's down to 12. I tried to keep the scope of this change as narrow as possible and keep the rest of the code intact, but these optimizations can be used elsewhere.
If you are open to more contributions, I'm happy to make some similar pull request.