### PR TITLE
Check mail config in listener

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Http\Controllers\Controller;
 use App\Models\EducationalInformation;
 use App\Models\Faculty;
-use App\Http\Controllers\Controller;
 use App\Models\PersonalInformation;
 use App\Models\Role;
 use App\Models\Semester;
@@ -53,7 +53,7 @@ class RegisterController extends Controller
             'user_type' => Role::COLLEGIST,
             'faculties' => Faculty::all(),
             'workshops' => Workshop::all(),
-            'countries' => require base_path('countries.php')
+            'countries' => require base_path('countries.php'),
         ]);
     }
 
@@ -63,7 +63,7 @@ class RegisterController extends Controller
             'user_type' => Role::TENANT,
             'faculties' => Faculty::all(),
             'workshops' => Workshop::all(),
-            'countries' => require base_path('countries.php')
+            'countries' => require base_path('countries.php'),
         ]);
     }
 
@@ -104,7 +104,8 @@ class RegisterController extends Controller
             case Role::TENANT:
                 return Validator::make($data, $common);
             case Role::COLLEGIST:
-                $data['educational_email'] = $data['educational_email'] . "@student.elte.hu";
+                $data['educational_email'] = $data['educational_email'].'@student.elte.hu';
+
                 return Validator::make($data, array_merge($common, $informationOfStudies));
             default:
                 throw new AuthorizationException();
@@ -154,7 +155,7 @@ class RegisterController extends Controller
                     'high_school' => $data['high_school'],
                     'neptun' => $data['neptun'],
                     'year_of_acceptance' => $data['year_of_acceptance'],
-                    'email' => $data['educational_email'] . "@student.elte.hu",
+                    'email' => $data['educational_email'].'@student.elte.hu',
                 ]);
                 foreach ($data['faculty'] as $key => $faculty) {
                     $user->faculties()->attach($faculty);
@@ -162,7 +163,7 @@ class RegisterController extends Controller
                 foreach ($data['workshop'] as $key => $workshop) {
                     $user->workshops()->attach($workshop);
                 }
-                $user->setStatus(Semester::ACTIVE, "Activated through registration");
+                $user->setStatus(Semester::ACTIVE, 'Activated through registration');
                 break;
             default:
                 throw new AuthorizationException();

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -170,9 +170,7 @@ class RegisterController extends Controller
         $user->internetAccess->setWifiUsername();
 
         // Send confirmation mail.
-        if (config('mail.active')) {
-            Mail::to($user)->queue(new \App\Mail\Confirmation($user->name));
-        }
+        Mail::to($user)->queue(new \App\Mail\Confirmation($user->name));
 
         return $user;
     }

--- a/app/Http/Controllers/Dormitory/FaultController.php
+++ b/app/Http/Controllers/Dormitory/FaultController.php
@@ -62,14 +62,9 @@ class FaultController extends Controller
 
     public function notifyStaff(Fault $fault, bool $reopen = false)
     {
-        if (config('mail.active')) {
-            $staffs= Role::getUsers(Role::STAFF);
-            foreach ($staffs as $staff) {
-                Mail::to($staff)->queue(new \App\Mail\NewFault(
-                    $staff->name,
-                    $fault,
-                    $reopen));
-            }
+        $staffs= Role::getUsers(Role::STAFF);
+        foreach ($staffs as $staff) {
+            Mail::to($staff)->queue(new \App\Mail\NewFault($staff->name, $fault, $reopen));
         }
     }
 }

--- a/app/Http/Controllers/Dormitory/FaultController.php
+++ b/app/Http/Controllers/Dormitory/FaultController.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Controller;
 use App\Models\Fault;
 use App\Models\Role;
 use Illuminate\Http\Request;
-
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Mail;
 
@@ -50,7 +49,7 @@ class FaultController extends Controller
         if ($auth) {
             $fault = Fault::findOrFail($request['id']);
             $fault->update([
-                'status' => Fault::getState($status)
+                'status' => Fault::getState($status),
             ]);
             if ($status === Fault::UNSEEN) {
                 $this->notifyStaff($fault, /* reopen */ true);
@@ -62,7 +61,7 @@ class FaultController extends Controller
 
     public function notifyStaff(Fault $fault, bool $reopen = false)
     {
-        $staffs= Role::getUsers(Role::STAFF);
+        $staffs = Role::getUsers(Role::STAFF);
         foreach ($staffs as $staff) {
             Mail::to($staff)->queue(new \App\Mail\NewFault($staff->name, $fault, $reopen));
         }

--- a/app/Http/Controllers/Dormitory/PrintController.php
+++ b/app/Http/Controllers/Dormitory/PrintController.php
@@ -10,6 +10,7 @@ use App\Models\FreePages;
 use App\Models\PrintAccount;
 use App\Models\PrintJob;
 use App\Models\PrintAccountHistory;
+use App\Mail\ChangedPrintBalance;
 use App\Utils\Printer;
 use App\Utils\TabulatorPaginator;
 use App\Models\Transaction;
@@ -109,9 +110,7 @@ class PrintController extends Controller
         $to_account->increment('balance', $balance);
 
         // Send notification mail
-        if (config('mail.active')) {
-            Mail::to($user)->queue(new \App\Mail\ChangedPrintBalance($user, $balance, Auth::user()->name));
-        }
+        Mail::to($user)->queue(new ChangedPrintBalance($user, $balance, Auth::user()->name));
 
         return redirect()->back()->with('message', __('general.successful_transaction'));
     }
@@ -148,9 +147,7 @@ class PrintController extends Controller
         ]);
 
         // Send notification mail
-        if (config('mail.active')) {
-            Mail::to($user)->queue(new \App\Mail\ChangedPrintBalance($user, $balance, Auth::user()->name));
-        }
+        Mail::to($user)->queue(new ChangedPrintBalance($user, $balance, Auth::user()->name));
 
         return redirect()->back()->with('message', __('general.successful_modification'));
     }

--- a/app/Http/Controllers/Secretariat/DocumentController.php
+++ b/app/Http/Controllers/Secretariat/DocumentController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Secretariat;
 
+use App\Models\Role;
 use App\Models\User;
 use App\Models\Semester;
 use App\Models\ImportItem;
@@ -112,14 +113,11 @@ class DocumentController extends Controller
         Gate::authorize('document.status-certificate');
 
         $url = route('documents.status-cert.show', ['id' => Auth::user()->id]);
-        if (config('mail.active')) {
-            $secretaries = User::whereHas('roles', function($q){
-                $q->where('name', \App\Models\Role::SECRETARY);
-            })->get();
-            foreach ($secretaries as $recipient) {
-                Mail::to($recipient)->queue(new \App\Mail\StateCertificateRequest($recipient->name, Auth::user()->name, $url));
-            }
+        $secretaries = User::role(Role::SECRETARY)->get();
+        foreach ($secretaries as $recipient) {
+            Mail::to($recipient)->queue(new \App\Mail\StateCertificateRequest($recipient->name, Auth::user()->name, $url));
         }
+
         return redirect()->back()->with('message', __('document.successful_request'));
     }
 

--- a/app/Http/Controllers/Secretariat/RegistrationsController.php
+++ b/app/Http/Controllers/Secretariat/RegistrationsController.php
@@ -35,9 +35,7 @@ class RegistrationsController extends Controller
         Cache::decrement('user');
 
         // Send notification mail.
-        if (config('mail.active')) {
-            Mail::to($user)->queue(new \App\Mail\ApprovedRegistration($user->name));
-        }
+        Mail::to($user)->queue(new \App\Mail\ApprovedRegistration($user->name));
         if($request->next){
             $next_user = User::withoutGlobalScope('verified')->where('verified', false)->first();
             if($next_user != null) {

--- a/app/Http/Controllers/Secretariat/RegistrationsController.php
+++ b/app/Http/Controllers/Secretariat/RegistrationsController.php
@@ -3,11 +3,10 @@
 namespace App\Http\Controllers\Secretariat;
 
 use App\Http\Controllers\Controller;
-
+use App\Models\User;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Mail;
-use Illuminate\Http\Request;
-use App\Models\User;
 
 class RegistrationsController extends Controller
 {
@@ -26,7 +25,7 @@ class RegistrationsController extends Controller
     public function accept(Request $request)
     {
         $user = User::withoutGlobalScope('verified')->findOrFail($request->id);
-        if($user->verified) {
+        if ($user->verified) {
             return redirect()->route('secretariat.registrations');
         }
 
@@ -36,19 +35,20 @@ class RegistrationsController extends Controller
 
         // Send notification mail.
         Mail::to($user)->queue(new \App\Mail\ApprovedRegistration($user->name));
-        if($request->next){
+        if ($request->next) {
             $next_user = User::withoutGlobalScope('verified')->where('verified', false)->first();
-            if($next_user != null) {
+            if ($next_user != null) {
                 return redirect()->route('secretariat.registrations.show', ['id' => $next_user->id]);
             }
         }
+
         return redirect()->route('secretariat.registrations')->with('message', __('general.successful_modification'));
     }
 
     public function reject(Request $request)
     {
         $user = User::withoutGlobalScope('verified')->findOrFail($request->id);
-        if($user->verified) {
+        if ($user->verified) {
             return redirect()->route('secretariat.registrations');
         }
 
@@ -56,23 +56,25 @@ class RegistrationsController extends Controller
 
         Cache::decrement('user');
 
-        if($request->next){
+        if ($request->next) {
             $next_user = User::withoutGlobalScope('verified')->where('verified', false)->first();
-            if($next_user != null) {
+            if ($next_user != null) {
                 return redirect()->route('secretariat.registrations.show', ['id' => $next_user->id]);
             }
         }
+
         return redirect()->route('secretariat.registrations')->with('message', __('general.successful_modification'));
     }
 
     public function show(Request $request)
     {
         $user = User::withoutGlobalScope('verified')->findOrFail($request->id);
-        if($user->verified) {
+        if ($user->verified) {
             return redirect()->route('secretariat.registrations');
         }
 
         $unverified_users_left = count(User::withoutGlobalScope('verified')->where('verified', false)->get());
+
         return view('secretariat.registrations.show', ['user' => $user, 'users_left' => $unverified_users_left]);
     }
 }

--- a/app/Http/Controllers/StudentsCouncil/EconomicController.php
+++ b/app/Http/Controllers/StudentsCouncil/EconomicController.php
@@ -124,15 +124,13 @@ class EconomicController extends Controller
         ]);
 
         $new_internet_expire_date = InternetController::extendUsersInternetAccess($payer);
-        if (config('mail.active')) {
-            $internet_expiration_message = null;
-            if ($new_internet_expire_date !== null){
-                $internet_expiration_message = __('internet.expiration_extended', [
-                    'new_date' => $new_internet_expire_date->format('Y-m-d')
-                ]);
-            }
-            Mail::to($payer)->queue(new \App\Mail\PayedTransaction($payer->name, [$kkt, $netreg], $internet_expiration_message));
+        $internet_expiration_message = null;
+        if ($new_internet_expire_date !== null){
+            $internet_expiration_message = __('internet.expiration_extended', [
+                'new_date' => $new_internet_expire_date->format('Y-m-d')
+            ]);
         }
+        Mail::to($payer)->queue(new \App\Mail\PayedTransaction($payer->name, [$kkt, $netreg], $internet_expiration_message));
 
         return redirect()->back()->with('message', __('general.successfully_added'));
     }

--- a/app/Http/Controllers/StudentsCouncil/EconomicController.php
+++ b/app/Http/Controllers/StudentsCouncil/EconomicController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\StudentsCouncil;
 
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\Network\InternetController;
 use App\Models\Checkout;
 use App\Models\PaymentType;
 use App\Models\Role;
@@ -9,14 +11,11 @@ use App\Models\Semester;
 use App\Models\Transaction;
 use App\Models\User;
 use App\Models\WorkshopBalance;
-use App\Http\Controllers\Controller;
-use App\Http\Controllers\Network\InternetController;
 use App\Utils\CheckoutHandler;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Validator;
-
 
 class EconomicController extends Controller
 {
@@ -36,9 +35,10 @@ class EconomicController extends Controller
 
         $view = view('student-council.economic-committee.app', $checkoutData);
 
-        if($redirected){
+        if ($redirected) {
             return $view->with('message', __('general.successfully_added'));
         }
+
         return $view;
     }
 
@@ -63,7 +63,7 @@ class EconomicController extends Controller
 
         return view('student-council.economic-committee.kktnetreg', $checkoutData)
             ->with('users', $users_has_to_pay_kktnetreg);
-}
+    }
 
     public function indexTransaction()
     {
@@ -125,9 +125,9 @@ class EconomicController extends Controller
 
         $new_internet_expire_date = InternetController::extendUsersInternetAccess($payer);
         $internet_expiration_message = null;
-        if ($new_internet_expire_date !== null){
+        if ($new_internet_expire_date !== null) {
             $internet_expiration_message = __('internet.expiration_extended', [
-                'new_date' => $new_internet_expire_date->format('Y-m-d')
+                'new_date' => $new_internet_expire_date->format('Y-m-d'),
             ]);
         }
         Mail::to($payer)->queue(new \App\Mail\PayedTransaction($payer->name, [$kkt, $netreg], $internet_expiration_message));
@@ -150,6 +150,7 @@ class EconomicController extends Controller
     {
         $checkout = Checkout::studentsCouncil();
         $this->createTransaction($request, $checkout);
+
         return redirect()->action(
             [EconomicController::class, 'index'], ['redirected' => true]
         );
@@ -159,10 +160,12 @@ class EconomicController extends Controller
     {
         $this->authorize('administrate', Checkout::studentsCouncil());
         WorkshopBalance::generateBalances();
+
         return redirect()->back()->with('message', __('general.successful_modification'));
     }
 
-    public static function routeBase() {
+    public static function routeBase()
+    {
         return 'economic_committee';
     }
 }

--- a/app/Listeners/MailGate.php
+++ b/app/Listeners/MailGate.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Listeners;
+
+class MailGate
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  object  $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        // Prevent the propagation of the event here, therefore stopping the mail.
+        if (config('app.debug') && !config('mail.active')) {
+            return false;
+        }
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -5,12 +5,12 @@ namespace App\Providers;
 use App\Events\MacAddressDeleted;
 use App\Events\MacAddressSaved;
 use App\Listeners\AutoApproveMacAddresses;
-use App\Listeners\UpdatePhysicalIP;
 use App\Listeners\MailGate;
+use App\Listeners\UpdatePhysicalIP;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
-use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Mail\Events\MessageSending;
 
 class EventServiceProvider extends ServiceProvider
 {

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -6,8 +6,10 @@ use App\Events\MacAddressDeleted;
 use App\Events\MacAddressSaved;
 use App\Listeners\AutoApproveMacAddresses;
 use App\Listeners\UpdatePhysicalIP;
+use App\Listeners\MailGate;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
+use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider
@@ -27,6 +29,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         MacAddressDeleted::class => [
             AutoApproveMacAddresses::class,
+        ],
+        MessageSending::class => [
+            MailGate::class,
         ],
     ];
 


### PR DESCRIPTION
Fixes #458 
I find this an elegant way to still get the mails when we want to check the final version of them, but there's no need to add (and sometimes by mistake miss adding) the `mail.active` check.
This is still set through the `MAIL_ACTIVE` env variable.