### PR TITLE
CheckoutHandler optimizazions

### DIFF
--- a/app/Models/Checkout.php
+++ b/app/Models/Checkout.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
 
 class Checkout extends Model
 {
@@ -35,12 +36,16 @@ class Checkout extends Model
 
     public static function admin()
     {
-        return self::where('name', self::ADMIN)->firstOrFail();
+        return Cache::remember('checkout.'.self::ADMIN, 86400, function () {
+            return self::where('name', self::ADMIN)->firstOrFail();
+        });
     }
 
     public static function studentsCouncil()
     {
-        return self::where('name', self::STUDENTS_COUNCIL)->firstOrFail();
+        return Cache::remember('checkout.'.self::STUDENTS_COUNCIL, 86400, function () {
+            return self::where('name', self::STUDENTS_COUNCIL)->firstOrFail();
+        });
     }
 
     public function kktSum(Semester $semester)


### PR DESCRIPTION
Some small changes: 
- missing cache for the Checkout model
- eager loading for transactions not in checkout
- eager loading relations after the where clause for semesters (this change doesn't make a huge difference in this particular case, but in general it's better to use `load()` if you want to filter the results after `get()`)