### PR TITLE
Issue #580: Select inits are loaded multiple times

### DIFF
--- a/app/View/Components/Input/Select.php
+++ b/app/View/Components/Input/Select.php
@@ -11,6 +11,7 @@ class Select extends Input
     public $withoutLabel;
     public $default;
     public $allowEmpty;
+    public $once;
 
     /**
      * Create a new select component instance with a search field.
@@ -18,9 +19,11 @@ class Select extends Input
      * @param $withoutPlaceholder (the default placeholder is general.choose, that can be overwritten with a placeholder attribute)
      * @param $withoutLabel
      * @param $default the default value (the id will be matched)
+     * @param $once if set, the init script will be run only once. This optimizes pages with multiple select components which have the
+     *        same element list, but would break selects with different element lists.
      * @return void
      */
-    public function __construct($id, $elements, $withoutPlaceholder = false, $withoutLabel = false, $default = null, $locale = null, $text = null, $s = 12, $m = null, $l = null, $xl = null, $onlyInput = false, $allowEmpty = false)
+    public function __construct($id, $elements, $withoutPlaceholder = false, $withoutLabel = false, $default = null, $locale = null, $text = null, $s = 12, $m = null, $l = null, $xl = null, $onlyInput = false, $allowEmpty = false, $once = false)
     {
         parent::__construct($id, $locale, $text, $s, $m, $l, $xl, $onlyInput);
         $this->elements = (isset($elements[0]->name) ? $elements->sortBy('name') : $elements);
@@ -28,6 +31,7 @@ class Select extends Input
         $this->withoutLabel = $withoutLabel;
         $this->default = $default;
         $this->allowEmpty = $allowEmpty;
+        $this->once = $once;
     }
 
     /**

--- a/resources/views/components/input/datepicker.blade.php
+++ b/resources/views/components/input/datepicker.blade.php
@@ -20,15 +20,4 @@
 </div>
 @endif
 
-@push('scripts')
-    <script>
-        $(document).ready(function() {
-            $('.datepicker_{{$id}}').datepicker({
-                format: '{{$format}}',
-                firstDay: 1,
-                yearRange: {{$yearRange}},
-                showClearBtn: true
-            });
-        });
-    </script>
-@endpush
+@include('components.input.init.datepicker')

--- a/resources/views/components/input/init/datepicker.blade.php
+++ b/resources/views/components/input/init/datepicker.blade.php
@@ -1,0 +1,12 @@
+@push('scripts')
+    <script>
+        $(document).ready(function() {
+            $('.datepicker_{{$id}}').datepicker({
+                format: '{{$format}}',
+                firstDay: 1,
+                yearRange: {{$yearRange}},
+                showClearBtn: true
+            });
+        });
+    </script>
+@endpush

--- a/resources/views/components/input/init/select.blade.php
+++ b/resources/views/components/input/init/select.blade.php
@@ -1,0 +1,16 @@
+@push('scripts')
+    <script>
+        //Initialize materialize select
+        var instances;
+        $(document).ready(
+        function() {
+            var elems = $('#{{ $id }}');
+            const options = [
+            @foreach ($elements as $element)
+                { name : '{{ $element->name ?? $element }}',  value : '{{ $element->id ?? $element }}'},
+            @endforeach
+            ];
+            instances = M.FormSelect.init(elems, options);
+        });
+  </script>
+@endpush

--- a/resources/views/components/input/init/timepicker.blade.php
+++ b/resources/views/components/input/init/timepicker.blade.php
@@ -1,0 +1,10 @@
+@push('scripts')
+    <script>
+        $(document).ready(function() {
+            $('.timepicker').timepicker({
+                showClearBtn: true,
+                twelveHour: false,
+            });
+        });
+    </script>
+@endpush

--- a/resources/views/components/input/select.blade.php
+++ b/resources/views/components/input/select.blade.php
@@ -37,19 +37,10 @@
 </div>
 @endif
 
-@push('scripts')
-    <script>
-        //Initialize materialize select
-        var instances;
-        $(document).ready(
-        function() {
-            var elems = $('#{{ $id }}');
-            const options = [
-            @foreach ($elements as $element)
-                { name : '{{ $element->name ?? $element }}',  value : '{{ $element->id ?? $element }}'},
-            @endforeach
-            ];
-            instances = M.FormSelect.init(elems, options);
-        });
-  </script>
-@endpush
+@if ($once)
+  @once
+    @include('components.input.init.select')
+  @endonce
+@else
+  @include('components.input.init.select')
+@endif

--- a/resources/views/components/input/timepicker.blade.php
+++ b/resources/views/components/input/timepicker.blade.php
@@ -20,13 +20,4 @@
 </div>
 @endif
 
-@push('scripts')
-    <script>
-        $(document).ready(function() {
-            $('.timepicker').timepicker({
-                showClearBtn: true,
-                twelveHour: false,
-            });
-        });
-    </script>
-@endpush
+@include('components.input.init.timepicker')

--- a/resources/views/student-council/mr-and-miss/votefields.blade.php
+++ b/resources/views/student-council/mr-and-miss/votefields.blade.php
@@ -16,7 +16,7 @@
                 hidden
               @endif
             >
-              <x-input.select only-input :id="'select-' . $category->id" :elements="$users" without-placeholder allow-empty without-label
+              <x-input.select only-input :id="'select-' . $category->id" :elements="$users" without-placeholder allow-empty without-label once
                   :default="($voteInfo['voted'] && $voteInfo['vote']->votee_id !== null ? $voteInfo['vote']->votee_id : null)"
                 />
             </div>


### PR DESCRIPTION
This might cause slowness on pages with multiple selects, like on the mr and miss page.
Instead of including the scripts multiple times, which has a lot of content (the whole user list), we could load it only once.

This commit adds a `once` attribute to the select component, which would let us load the select init script once per page. Note that this can be used only if we have exactly once type of select on the page, as the other would break, since they won't have the same user list in their init script.

Fixes #580.