### PR TITLE
#561: Epistola: SQL error: Data too long for column 'picture_path'

### DIFF
--- a/app/Http/Controllers/StudentsCouncil/EpistolaController.php
+++ b/app/Http/Controllers/StudentsCouncil/EpistolaController.php
@@ -90,7 +90,7 @@ class EpistolaController extends Controller
             'deadline_date' => 'nullable|date|required_with:deadline_name',
             'approved' => 'nullable|required_with:picture_upload',
             'picture_upload' => 'nullable|image',
-            'picture_path' => ['nullable', 'url', function ($attribute, $value, $fail) use ($request) {
+            'picture_path' => ['nullable', 'url', 'max:255', function ($attribute, $value, $fail) use ($request) {
                 if ($request->picture_upload != null && $request->picture_path != null)
                     $fail(__('validation.upload_with_link'));
             }]


### PR DESCRIPTION
Fixes #561. It now reloads and the error message looks like this; should that be improved?
![Bildschirmfoto von 2021-10-07 19-24-36](https://user-images.githubusercontent.com/70488334/136434253-a8cf0dfd-6559-4bb2-87bc-b9bf32cb540d.png)