### PR TITLE
Add invitation LaTeX file for Students' committee

### DIFF
--- a/resources/views/latex/invitation.tex
+++ b/resources/views/latex/invitation.tex
@@ -1,0 +1,122 @@
+\documentclass[12pt,a4paper]{article}
+\usepackage[utf8]{inputenc}
+\usepackage[magyar]{babel}
+\usepackage{amsmath}
+\usepackage{graphicx}
+\usepackage{multirow}
+
+\usepackage{caption}
+\usepackage[letterspace=300]{microtype}
+
+\usepackage{atbegshi}
+\usepackage{tikz}
+\usepackage[left=2cm, right=2cm, top=5cm, bottom=1cm]{geometry}
+\definecolor{darkblue}{rgb}{0.2, 0.2, 0.7}
+\title{Meghívó\vspace{-1.0cm}}
+\date{}
+\author{}
+\pagenumbering{gobble}
+
+\usepackage{parskip}
+\setlength{\parindent}{0pt}
+
+\newcommand\Header{
+        \begin{tikzpicture}[remember picture,overlay]
+        \fill[blue!40] (-\paperwidth,0.3) rectangle (2\paperwidth, -0.3);
+        \fill[white] (\paperwidth/2 - 70,0) ellipse (3.2 and 1.25);
+        \node[inner sep=0pt] (picture) at (\paperwidth/2 - 70,0.2){\includegraphics[width=5cm]{epulet.png}};
+        \node[inner sep=0pt, text=white] (from) at (2.9, -0.05){\textbf{1 9 1 0  /  1 9 1 1}};
+        \node[inner sep=0pt, text=white] (from) at (13.2, -0.05){\textbf{2 0 1 0  /  2 0 1 1}};
+        \node[inner sep=0pt, text=blue!75!black] (from) at (\paperwidth/2 - 75,-1.5){\LARGE {\lsstyle LUSTRUM SAECULARE COLLEGII}};
+        \node[inner sep=0pt] (from) at (\paperwidth/2 - 70,-2.5){\large  \textit{\lsstyle Szabadon szolgál a szellem}};
+        \end{tikzpicture}
+}
+
+\newcommand\Footer{
+
+	{\footnotesize 
+	\begin{minipage}[t]{0.4\textwidth}
+		\begin{flushright}
+		\textsc{
+            {\color{darkblue} 
+			ELTE EÖTVÖS JÓZSEF\\
+			COLLEGIUM}\\
+		    {\scriptsize 
+		    Dr. Horváth László\\
+			igazgató\\
+			Varga Sára\\
+			választmányi elnök\\
+            }
+            }
+		\end{flushright}
+	\end{minipage}
+	\hspace{1em}
+	\begin{minipage}[t]{0.45\textwidth}
+		\begin{flushleft}
+			{\scriptsize H-1118 Budapest, Ménesi út 11-13\\
+			Tel.: +36 1 460 4481 • Fax.: +36 1 209 2044\\
+			E-mail:	titkarsag@eotvos.elte.hu • horvathl@eotvos.elte.hu
+			valasztmany@eotvos.elte.hu • elnok@eotvos.elte.hu\\
+			Honlap: http://www.eotvos.elte.hu/ }
+		\end{flushleft}
+	\end{minipage}
+	}
+}
+
+
+\pagestyle{empty}
+\AtBeginShipoutFirst{\Header}
+
+\newcommand{\signiture}[3]{
+\begin{center}
+	#1\\
+	#2\\
+	#3
+\end{center}
+}
+
+\begin{document}
+
+\vspace*{0.5cm}
+\textbf{ELTE EJC CHÖK tagja}\\
+részére\\
+\\
+\textbf{Tárgy}: \emph{TODO}\\ 
+\\
+\textbf{Kedves Bizottsági Tag, Kedves Meghívott!}\\
+\\
+Tisztelettel meghívlak az ELTE Eötvös József Collegium TODO következő
+ülésére. Az ülés tervezett kezdő időpontja és helyszíne:
+
+\begin{center}
+\textbf{
+TODO,\\
+TODO
+}
+\end{center}
+
+Az ülés tervezett napirendi pontjai az alábbiak:
+
+\begin{enumerate}
+    \item TODO
+\end{enumerate}
+
+\leavevmode\\
+Budapest, \today \\
+\\
+Megjelenésedben bízva, üdvözlettel:
+\vspace{5em}
+
+\begin{flushright}
+\begin{minipage}[t]{0.4\textwidth}
+	\signiture{TODO}{elnök}{TODO}
+\end{minipage}
+\end{flushright}
+
+\vfill
+
+\begin{center}
+	\Footer
+\end{center}
+
+\end{document}


### PR DESCRIPTION
This commit adds the LaTeX file that could be used as a template to generate invitations for the Students' Committees. I left TODO where some input is required.

Please review the template first, and then I'll start working on the next steps.

This is how the compiled file looks like:
[meghivo.pdf](https://github.com/luksan47/mars/files/7360062/meghivo.pdf)
